### PR TITLE
Create year directory as needed

### DIFF
--- a/re
+++ b/re
@@ -293,13 +293,16 @@ $vars{WEEK} = $weekofyear;
 $vars{YEAR} = $startyear;
 $vars{TIMESTAMP} = scalar localtime;
 
+# If the year directory does not exist, create it.
+make_path( $dir ) unless ( -e $dir && -d $dir );
+
 # If the file does not exist, fill it with the template.
 unless( -e $file ) {
   if( open FILE, ">$file" ) {
     print FILE template( \%vars );
     close FILE;
   } else {
-    die "Failed to open report file to write: $!\n";
+    die "Failed to open report file to write: $!\n$file\n";
   }
 }
 


### PR DESCRIPTION
The re script creates the "weekly_reports" directory automatically, but it doesn't create the subdirectory for the year, like "weekly_reports/2017", and so the script fails the first time it attempts to write a weekly report. This patch automatically creates the year subdirectory, and also includes the full file path in the error message to make it easier to debug file opening failures.